### PR TITLE
Updated pipeline_prf to use nifti_convert module and remove previous step files/folders.

### DIFF
--- a/Development/nifti_convert.m
+++ b/Development/nifti_convert.m
@@ -1,0 +1,62 @@
+function ni_files = nifti_convert(fld, varargin)
+% ni_files = nifti_convert(fld, 'field', 'value',... [,'verboseOFF']) 
+% 
+% Inputs:
+% fld - string or cellstr of path(s) of directories containing dicom files
+% to convert
+%
+% Other inputs for dcm2niix:
+%   -b : BIDS sidecar (y/n, default n)
+%   -f : filename (%a=antenna  (coil) number, %c=comments, %d=description,
+% %e echo number, %f=folder name, %i ID of patient, %m=manufacturer, 
+% %n=name of patient, %p=protocol, %s=series number, %t=time, 
+% %u=acquisition number, %z sequence name)
+%   -m : merge 2D slices from same series regardless of study time, echo, 
+% coil, orientation, etc. (y/n, default n)
+%   -o : output directory (omit to save to input folder)
+%   -s : single file mode, do not convert other images in folder (y/n, default n)
+%   -t : text notes includes private patient details (y/n, default n)
+%   -v : verbose (y/n, default n)
+%   -x : crop (y/n, default n)
+%   -z : gz compress images (y/i/n, default y) [y=pigz, i=internal, n=no]
+%
+% Other inputs:
+% 'verboseOFF' - Turn off command prompt text (default is 'verboseON')
+%
+% Outputs:
+% ni_files - cell array of paths to newly created nifti files
+%
+% Example:
+% dcm_dirs = fullfile('/Users/Raw_DICOM',{'ep01','ep02','t1_mprage_03'});
+% ni_files = nifti_convert(dcm_dirs, '-o', '/Users/Nifti', '-f', {'epi_1','epi_2','mprage'})
+%
+% Created by Justin Theiss
+
+% init vars
+if ~exist('fld','var')||isempty(fld), fld = pwd; end;
+if ~iscell(fld), fld = {fld}; end;
+if ~any(strncmp(varargin,'verbose',7)),
+    verbose = 'verboseON';
+else % verboseOFF and remove
+    verbose = varargin{strncmp(varargin,'verbose',7)};
+    varargin(strncmp(varargin,'verbose',7)) = [];
+end
+
+% get out directories
+if ~any(strcmp(varargin,'-o')),
+    out_dir = fld;
+else
+    out_dir = varargin{find(strcmp(varargin,'-o'))+1};
+    if ~iscell(out_dir), out_dir = {out_dir}; end;
+end
+
+% run dcm2niix with loop_system
+loop_system('dcm2niix',varargin{:},fld(:),verbose);
+
+% return newly created files
+ni_files = cell(size(out_dir));
+for x = 1:numel(out_dir),
+    ni_files{x} = get_dir(out_dir{x}, '*.nii*');
+end
+ni_files = [ni_files{:}];
+end

--- a/Development/nifti_convert.m
+++ b/Development/nifti_convert.m
@@ -42,6 +42,9 @@ else % verboseOFF and remove
     varargin(strncmp(varargin,'verbose',7)) = [];
 end
 
+% display inputs
+dispi(mfilename,'\nfld: ',fld,'\nvarargin: ',varargin{:},verbose);
+
 % get out directories
 if ~any(strcmp(varargin,'-o')),
     out_dir = fld;

--- a/Development/remove_dir.m
+++ b/Development/remove_dir.m
@@ -1,0 +1,106 @@
+function [success, status] = remove_dir(varargin)
+% [success, status] = remove_dir(folders/files, ['s'], ['verboseOFF'], ['errorON'])
+%
+% Removes folders/files if they exist.
+%
+% Inputs:
+% folder/file: string/cell array of strings corresponding to the folders/files
+% to remove
+% s: remove all subdirectories of folder (as in call rmdir(fld,'s'),
+% default is none)
+% verbose: 'verboseOFF' to prevent output displays (default is 'verboseON')
+% err: 'errorON' to throw error if unable to remove a found folder (default
+% is 'errorOFF')
+% 
+% Outputs:
+% success: cell array of 1/0 for success/failure of removing existing
+% folders
+% status: cell array of status from each rmdir call
+%
+% Example: make 2 test folders, and attempt to remove 3
+% flds = fullfile(pwd, {'test1', 'test2', 'test3'});
+% mkdir(flds{1}); mkdir(flds{3});
+% [success, status] = remove_previous(fullfile(pwd,{'test1','test2','test3'}),'s','errorON')
+%
+% /Users/test1 detected and removed
+% /Users/test2 not detected
+% /Users/test3 detected and removed
+% 
+% success = 
+% 
+%     [1]    []    [1]
+% 
+% 
+% status = 
+% 
+%     ''    []    ''
+%
+% Written Nov 2016
+% Adrien Chopin
+
+% init vars
+if nargin==0,
+    return;
+elseif ~ischar(varargin{1}) && ~iscell(varargin{1}),
+    return;
+end
+if any(strncmp(varargin,'verbose',7)), 
+    verbose = varargin{strncmp(varargin,'verbose',7)};
+    varargin(strcmp(varargin,verbose)) = [];
+else % default on
+    verbose = 'verboseON';
+end
+if any(strncmp(varargin,'error',5)),
+    err = varargin{strncmp(varargin,'error',5)};
+    varargin(strcmp(varargin,err)) = [];
+else % default off
+    err = 'errorOFF';
+end
+% set to folder(s)
+dirs = varargin{1};
+if ~iscell(dirs), dirs = {dirs}; end;
+% set s
+if numel(varargin)==2,
+    s = varargin{2};
+else % default none
+    s = '';
+end
+% remove non-char cells
+dirs(~cellfun('isclass',dirs,'char')) = [];
+% if any wildcards, get dir
+wld_idx = find(~cellfun('isempty',strfind(dirs,'*')));
+if any(wld_idx),
+    for x = wld_idx,
+        d = dir(dirs{x});
+        dirs = cat(2, dirs, {d.name});
+    end
+    dirs(wld_idx) = [];
+end
+% init outputs
+success = cell(size(dirs)); status = cell(size(dirs));
+% if folder exists, remove
+for x = 1:numel(dirs),
+    if exist(dirs{x},'dir')
+        if isempty(s), % dont remove subdirectories
+            [success{x}, status{x}] = rmdir(dirs{x}); 
+        else % remove subdirectories
+            [success{x}, status{x}] = rmdir(dirs{x}, s);
+        end
+    elseif exist(dirs{x},'file') % delete file
+        try % delete files
+            delete(dirs{x});
+            success{x} = true;
+            status{x} = '';
+        catch ME
+            success{x} = false;
+            status{x} = ME.message;
+        end
+    end
+    if success{x}, % display folder/file removed
+            dispi(dirs{x}, ' removed', verbose);
+    elseif ~success{x}, % warning/error
+        warning_error(status{x}, err, verbose); 
+    else % display not detected
+        dispi(dirs{x},' not detected',verbose)
+    end
+end


### PR DESCRIPTION
This update incorporates the ability to remove previous folders/files from steps that have been run by using the params.outputs field. The remove_dir function will only attempt to remove files/folders that exist (i.e. will not do anything if input is a number/structure/etc.). Furthermore, I've created a nifti_convert module that works well with the way we want our conversion to run. Finally, I've updated the create_params function to be more intuitive so users can input directories, files, numbers, cells, or text.